### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/environments/ai_msft_autogen_20231003_win.lock.yml
+++ b/environments/ai_msft_autogen_20231003_win.lock.yml
@@ -335,7 +335,7 @@ dependencies:
       - pbr==5.11.1
       - portalocker==2.8.2
       - prettytable==3.9.0
-      - pyautogen==0.1.12
+      - ag2==0.1.12
       - pydantic==1.10.9
       - pydash==7.0.5
       - pyjwt==2.8.0

--- a/environments/ai_msft_autogen_20231003_win.yml
+++ b/environments/ai_msft_autogen_20231003_win.yml
@@ -47,7 +47,7 @@ dependencies:
     - mlflow
     - ipykernel
     - nltk
-    - pyautogen[blendsearch,mathchat]
+    - ag2[blendsearch,mathchat]
     - lightgbm[scikit-learn,pandas]
 
     # INSTALLED IN OTHER ENVIRONMENTS:


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
